### PR TITLE
Changes in preparation for 02

### DIFF
--- a/draft-ietf-tls-pake.md
+++ b/draft-ietf-tls-pake.md
@@ -39,6 +39,34 @@ author:
    organization: Apple, Inc.
    email: caw@heapingbits.net
 
+normative:
+  PQPAKE:
+    title: "Hybrid Post-Quantum Password Authenticated Key Exchange"
+    target: https://datatracker.ietf.org/doc/draft-vos-cfrg-pqpake/
+    date: 2026
+    author:
+      - ins: J. Vos
+      - ins: C. A. Wood
+    seriesinfo:
+      Internet-Draft: draft-vos-cfrg-pqpake-latest
+  XWING:
+    title: "X-Wing: The Hybrid KEM You've Been Looking For"
+    target: https://datatracker.ietf.org/doc/draft-connolly-cfrg-xwing-kem/
+    date: 2024
+    author:
+      - ins: D. Connolly
+      - ins: P. Schwabe
+      - ins: B. Westerbaan
+    seriesinfo:
+      Internet-Draft: draft-connolly-cfrg-xwing-kem-latest
+
+informative:
+  ARGON2:
+    title: "Argon2 Memory-Hard Function for Password Hashing and Proof-of-Work Applications"
+    seriesinfo:
+      RFC: 9106
+    date: 2022
+
 
 --- abstract
 
@@ -89,7 +117,9 @@ password (e.g. augmented PAKEs only require one party to know the
 actual password). The choice of PAKE and any required parameters will
 be explicitly specified using IANA assigned values.
 This document defines concrete protocols for executing the
-SPAKE2+ {{!RFC9383}} and CPACE {{!CPACE=I-D.irtf-cfrg-cpace}} PAKE protocols.
+SPAKE2+ {{!RFC9383}}, CPACE {{!CPACE=I-D.irtf-cfrg-cpace}},
+OQUAKE {{PQPAKE}}, and
+OQUAKE+ {{PQPAKE}} PAKE protocols.
 
 # Terminology
 
@@ -111,10 +141,30 @@ Servers will of course have multiple instances of this configuration
 information for different clients. Clients may also have multiple
 identities, even within a given server.
 
-# PAKE Integration in TLS
+# PAKE Protocol Classification
 
-This section describes how the PAKE protocol is integrated and executed
-in the TLS handshake.
+This specification defines support for two classes of PAKE protocols:
+
+Internal PAKEs integrate directly into the TLS handshake, completing authentication
+within two messages (ClientHello and ServerHello). These PAKEs execute their protocol
+messages within the `pake` extension and derive shared secrets that feed into the TLS
+key schedule.
+
+External PAKEs require out-of-band execution prior to TLS connection establishment.
+These PAKEs complete their protocol exchange outside of TLS and import their derived
+secrets as PSKs using External PSK Import {{?RFC9258}}.
+
+The following sections describe both approaches in detail.
+
+# Internal PAKE Integration in TLS
+
+This section describes how Internal PAKE protocols are integrated and executed
+within the TLS handshake using the `pake` extension. Internal PAKEs complete their
+authentication exchange within two messages (ClientHello and ServerHello) and integrate
+their derived secrets directly into the TLS key schedule.
+
+For External PAKEs that execute out-of-band prior to TLS connection establishment,
+see {{external-pakes}}.
 
 ## Client Behavior
 
@@ -134,6 +184,8 @@ structure:
 enum {
     SPAKE2PLUS_V1 (0xXXXX),
     CPACE_X25519_SHA512 (0xXXXX),
+    OQUAKE_V1 (0xXXXX),
+    OQUAKE_PLUS_V1 (0xXXXX),
 } PAKEScheme;
 
 struct {
@@ -198,7 +250,17 @@ is always combined with the normal TLS key exchange mechanism. See {{key-sched-m
 Combining the `pake` extension with the normal TLS key exchange mechanism
 using a hybrid or PQ key agreement protects against Harvest Now Decrypt
 Later Attacks where traffic recorded today may be decrypted by a Cryptographically
-Relevant Quantum Computer (CRQC) in the future.
+Relevant Quantum Computer (CRQC) in the future. This protection covers the
+resulting *application traffic* regardless of which PAKEScheme is negotiated.
+It does not, by itself, protect the *password*: if the negotiated PAKEScheme is
+purely classical (e.g., SPAKE2+ or CPace), a future CRQC that breaks the
+scheme's underlying classical assumption can still retroactively recover the
+password from the harvested `pake` extension messages, independent of whether
+the surrounding TLS key exchange was hybrid or PQ. Deployments concerned with
+retroactive password recovery, as opposed to only traffic confidentiality,
+should select a post-quantum PAKEScheme, such as OQUAKE, OQUAKE+, or
+CPaceOQUAKE+; see the Security Considerations of {{PQPAKE}} for a detailed
+treatment of this distinction.
 
 A client which sends both a `pake` and `signature_algorithms` extension indicates the client
 requires both PAKE authentication and standard server certificate authentication.
@@ -303,21 +365,22 @@ as an all-or-nothing oracle for whether a given (identity, password) pair
 is correct. If an attacker does not supply a correct pair, they do not learn
 anything beyond this fact.
 
-# Compatible PAKE Protocols
+# Internal PAKE Protocol Specifications {#internal-pake-protocols}
 
-In order to be usable with the `pake` extension, a PAKE protocol
+## Requirements for Internal PAKEs
+
+In order to be usable as Internal PAKEs with the `pake` extension, a PAKE protocol
 must specify some syntax for its messages, and the PAKE protocol
 MUST produce a shared secret in exactly two messages carried in the ClientHello
-and ServerHello. PAKE protocols that require more than two messages to derive a shared secret
-are not compatible with this extension.
+and ServerHello. Internal PAKEs complete their authentication exchange within the
+TLS handshake and cannot require additional message rounds.
 
 In addition, to be compatible with the security requirements of TLS
-1.3, PAKE protocols defined for use with TLS 1.3 MUST provide
+1.3, Internal PAKE protocols defined for use with TLS 1.3 MUST provide
 forward secrecy and MUST be able to achieve key confirmation via TLS 1.3
 Finished messages.
 
-
-A specification describing the use of a particular PAKE protocol with
+A specification describing the use of a particular Internal PAKE protocol with
 TLS must provide the following details:
 
 * A `PAKEScheme` registered value indicating pre-provisioned parameters;
@@ -326,21 +389,23 @@ TLS must provide the following details:
 * How the PAKE protocol is executed based on those messages; and
 * How the outputs of the PAKE protocol are used to create the PAKE portion of the`(EC)DHE` input to the TLS key schedule.
 
-Several current PAKE protocols satisfy these requirements, for
-example:
+Several current PAKE protocols satisfy these requirements for Internal PAKE usage,
+for example:
 
 * CPace {{!CPACE=I-D.irtf-cfrg-cpace}}
 * SPAKE2+ (described in {{spake2plus}}) {{!RFC9383}}
 * OPAQUE {{?OPAQUE=I-D.irtf-cfrg-opaque}}
+* OQUAKE (described in {{oquake}}) {{PQPAKE}}
+* OQUAKE+ (described in {{oquakeplus}}) {{PQPAKE}}
 
-# SPAKE2+ Integration {#spake2plus}
+## SPAKE2+ Integration {#spake2plus}
 
 This section describes the SPAKE2+ instantiation of the `pake` extension for TLS.
 The SPAKE2+ protocol is described in {{!SPAKE2PLUS=RFC9383}}.
 {{spake2plus-setup}} describes the setup required before the protocol runs,
 and {{spake2plus-run}} describes the protocol execution in TLS.
 
-## Protocol Setup {#spake2plus-setup}
+### Protocol Setup {#spake2plus-setup}
 
 The TLS client and server roles map to the `Prover` and `Verifier` roles in the
 SPAKE2+ specification, respectively. Clients are configured with a client
@@ -357,7 +422,7 @@ key derivation function `KDF`, and message authentication code `MAC`. Additional
 the PAKEScheme value for SPAKE2+ fully defines the constants for M and N
 as needed for the protocol; see {{Section 4 of SPAKE2PLUS}}.
 
-## Protocol Execution {#spake2plus-run}
+### Protocol Execution {#spake2plus-run}
 
 The content of one PAKEShare value in the PAKEClientHello structure consists
 of the PAKEScheme value `SPAKE2PLUS_V1` and the value `shareP` as computed in
@@ -420,14 +485,14 @@ The client and server do not additionally compute or verify confirmP
 as described in {{Section 3.4 of SPAKE2PLUS}}.
 See {{spake2plus-sec}} for more information about the safety of this approach.
 
-# CPace Integration {#cpace}
+## CPace Integration {#cpace}
 
 This section describes the CPace instantiation of the `pake` extension for TLS.
 The CPace protocol is described in {{!CPACE=I-D.irtf-cfrg-cpace}}.
 {{cpace-setup}} describes the setup required before the protocol runs, and
 {{cpace-run}} describes the protocol execution in TLS.
 
-## Protocol Setup {#cpace-setup}
+### Protocol Setup {#cpace-setup}
 
 The TLS client and server roles map to the 'initiator' and 'responder' roles in
 the CPace specification, respectively. The client and server must share a
@@ -439,7 +504,7 @@ described in {{Section 3.1 of !CPACE=I-D.irtf-cfrg-cpace}}.
 The PAKEScheme value for CPace specifies a cipher suite for the protocol,
 consisting of a group environment `G` and cryptographic hash function `H`.
 
-## Protocol Execution {#cpace-run}
+### Protocol Execution {#cpace-run}
 
 The content of one PAKEShare value in the PAKEClientHello structure consists of
 the PAKEScheme value `CPACE_X25519_SHA512` and the value `Ya` as computed in
@@ -461,6 +526,311 @@ specified in {{Section 7.1 of !TLS13=RFC8446}} or as the
 `concatenated_shared_secret` as specified in {{Section 3.3 of !I-D.ietf-tls-hybrid-design}}.
 Specifically, `ISK || (EC)DHE` is used as the `(EC)DHE` input to the key
 schedule in {{Section 7.1 of !TLS13=RFC8446}}, as shown above in {{spake2plus-run}}.
+
+## OQUAKE Integration {#oquake}
+
+This section describes the OQUAKE instantiation of the `pake` extension for TLS.
+The OQUAKE protocol is a post-quantum symmetric PAKE described in {{PQPAKE}}.
+{{oquake-setup}} describes the setup required before the protocol runs, and
+{{oquake-run}} describes the protocol execution in TLS.
+
+### Protocol Setup {#oquake-setup}
+
+The TLS client and server roles map to the 'initiator' and 'responder' roles in
+the OQUAKE specification, respectively. The client and server must share a
+password-related string (PRS). The client and server may optionally be configured
+with a session identifier and client and server identifiers, as described in
+{{Section 8.2 of PQPAKE}}.
+
+The PAKEScheme value for OQUAKE specifies the BUA-sKEM instance and KDF used
+by the protocol.
+
+### Protocol Execution {#oquake-run}
+
+The content of one PAKEShare value in the PAKEClientHello structure consists of
+the PAKEScheme value `OQUAKE_V1` and the output message from `OQUAKE.Init` as
+specified in {{Section 8.2.1 of PQPAKE}}.
+
+The content of the server PAKEShare value in the PAKEServerHello structure
+consists of the PAKEScheme value `OQUAKE_V1` and the output message from
+`OQUAKE.Respond` as specified in {{Section 8.2.2 of PQPAKE}}.
+
+Given these messages, the client runs `OQUAKE.Finish` to derive the session key `SK`.
+The OQUAKE response message includes a key confirmation value `h`. The client
+MUST verify this value as part of `OQUAKE.Finish`. If verification fails,
+clients SHOULD abort the handshake with a "decrypt_error" alert.
+
+The client and server both combine `SK` with the `(EC)DHE` shared secret as
+input to the TLS 1.3 key schedule, where the (EC)DHE shared secret is as
+specified in {{Section 7.1 of !TLS13=RFC8446}} or as the
+`concatenated_shared_secret` as specified in {{Section 3.3 of !I-D.ietf-tls-hybrid-design}}.
+Specifically, `SK || (EC)DHE` is used as the `(EC)DHE` input to the key
+schedule in {{Section 7.1 of !TLS13=RFC8446}}, as shown above in {{spake2plus-run}}.
+
+The OQUAKE `context` parameter is set to `None` for standalone use.
+The OQUAKE `sid` parameter SHOULD be left empty, relying on the TLS
+transcript binding via Finished messages for session uniqueness.
+Client-to-server key confirmation is provided via TLS 1.3 Finished messages.
+
+## OQUAKE+ Integration {#oquakeplus}
+
+This section describes the OQUAKE+ instantiation of the `pake` extension for TLS.
+OQUAKE+ is a post-quantum asymmetric PAKE (aPAKE) described in {{PQPAKE}}.
+{{oquakeplus-setup}} describes the setup required before the protocol runs, and
+{{oquakeplus-run}} describes the protocol execution in TLS.
+
+### Protocol Setup {#oquakeplus-setup}
+
+The TLS client and server roles map to the 'initiator' and 'responder' roles in
+the OQUAKE+ specification, respectively. Clients are configured with a client
+identity, server identity, password-related string (PRS), and salt. Clients use
+these to derive a verifier and seed via `GenVerifierMaterial` as described in
+{{Section 9.1.1 of PQPAKE}}.
+
+Similarly, servers are configured with a list of client identity, server identity,
+verifier, public key (pk), and salt values. Servers use the verifier and public key
+when completing the OQUAKE+ protocol. The values for the verifier and public key
+are generated using `GenVerifiers` as specified in {{Section 9.1.1 of PQPAKE}}.
+
+The PAKEScheme value for OQUAKE+ specifies the BUA-sKEM instance, KEM instance,
+KDF, and KSF used by the protocol.
+
+### Protocol Execution {#oquakeplus-run}
+
+The content of one PAKEShare value in the PAKEClientHello structure consists of
+the PAKEScheme value `OQUAKE_PLUS_V1` and the output message from `OQUAKE+.Init`
+as specified in {{Section 9.2.1 of PQPAKE}}, using the verifier as the
+password-related string.
+
+The content of the server PAKEShare value in the PAKEServerHello structure
+consists of the PAKEScheme value `OQUAKE_PLUS_V1` and the output message from
+`OQUAKE+.Respond` as specified in {{Section 9.2.2 of PQPAKE}}, using the verifier
+as the password-related string and the client's registered public key.
+
+Upon receiving the client's PAKEShare `pake_message` (denoted `init_msg`),
+the server produces the response message and derives its shared secret by
+invoking `OQUAKE+.Respond`, as specified in {{Section 9.2.2 of PQPAKE}}:
+
+~~~
+state, resp_msg = OQUAKE+.Respond(PRS, public_context, secret_context,
+                                   init_msg, pk)
+~~~
+
+Here, `PRS` is the client's verifier, `pk` is the client's registered public
+key, `secret_context` is `None`, and `public_context` is `encode_sid(sid, U, S)`,
+where `sid` is the session identifier and `U` and `S` are the client and
+server identifiers. This binds the session and party identities into the
+key confirmation values that `OQUAKE+.Respond` computes internally.
+
+The server's PAKEShare `pake_message` is `resp_msg`. The server's PAKE shared
+secret is the `server_key` component of `state`. Note that the server does
+not invoke `OQUAKE+.Verify` -- which would check `server_confirm` against a
+client-sent value -- since the TLS Finished message from the client serves
+this confirmation purpose instead. See {{oquakeplus-sec}} for more information
+about the safety of this approach.
+
+The server SHOULD NOT send application data before receiving a valid Finished
+message from the client, which serves as confirmation that the client
+derived the correct shared secret.
+
+Upon receiving the server's PAKEShare `pake_message` (denoted `resp_msg`),
+the client derives its shared secret by invoking `OQUAKE+.Finish`, as
+specified in {{Section 9.2.3 of PQPAKE}}:
+
+~~~
+client_key, response = OQUAKE+.Finish(state, seed, resp_msg, public_context)
+~~~
+
+Here, `state` is the opaque state produced by the client's earlier call to
+`OQUAKE+.Init`, `seed` is the seed from `GenVerifierMaterial`, and
+`public_context` is `encode_sid(sid, U, S)` as above. The client's PAKE
+shared secret is `client_key`; the `response` output value (the server's
+confirmation value) is not sent to the server, since the `pake` extension
+carries no third PAKEShare message for Internal PAKEs.
+
+If `OQUAKE+.Finish` raises `AuthenticationError` -- which covers the key
+confirmation value included in `resp_msg` not matching, `KEM.Decaps` failing,
+or the client confirmation value not matching -- the client MUST abort the
+handshake with a "decrypt_error" alert.
+
+The client and server both combine their PAKE shared secret (`client_key` and
+`server_key`, respectively) with the `(EC)DHE` shared secret as input to the
+TLS 1.3 key schedule, where the (EC)DHE shared secret is as
+specified in {{Section 7.1 of !TLS13=RFC8446}} or as the
+`concatenated_shared_secret` as specified in {{Section 3.3 of !I-D.ietf-tls-hybrid-design}}.
+Specifically, `client_key || (EC)DHE` is used as the `(EC)DHE` input to the key
+schedule in {{Section 7.1 of !TLS13=RFC8446}}, as shown above in {{spake2plus-run}}.
+
+The `secret_context` input to `OQUAKE+.Respond` and `OQUAKE+.Finish` is set
+to `None` for standalone use of OQUAKE+ as an Internal PAKE; it is not `None`
+when OQUAKE+ is composed with CPace, as in {{external-pakes}}.
+
+# External PAKE Integration {#external-pakes}
+
+## Overview {#external-overview}
+
+External PAKEs provide an alternative approach for applications requiring:
+
+* Multi-round PAKE protocols: Protocols requiring more than two messages to complete authentication
+* Complex hybrid constructions: Sequential combinations of multiple PAKE protocols
+* Application-controlled channels: Direct control over communication channels and timing
+* Separation of concerns: Clear boundary between PAKE execution and TLS connection establishment
+
+External PAKEs execute their complete protocol exchange outside of TLS, then integrate
+with TLS through External PSK Import {{?RFC9258}}. This approach enables protocols
+that cannot be constrained to the two-message limit of Internal PAKEs.
+
+## General Framework {#external-framework}
+
+External PAKE protocols must satisfy the following requirements:
+
+* High-entropy output: Must derive a cryptographically strong shared secret
+* PSK Import compatibility: Output must be suitable for External PSK Import per {{?RFC9258}}
+* Secure session binding: Must provide mechanism to correlate out-of-band execution with TLS connection
+* Forward secrecy: Must provide forward secrecy properties appropriate to the application
+
+The integration pattern for External PAKEs follows these phases:
+
+1. Out-of-band PAKE execution: Complete PAKE protocol exchange using application-controlled channels
+2. PSK derivation: Use External PSK Import to derive TLS PSK from PAKE output
+3. TLS PSK connection: Establish TLS connection using standard PSK mechanisms
+4. Session correlation: Verify proper binding between PAKE execution and TLS connection
+
+## CPaceOQUAKE+ Integration {#cpaceoquakeplus}
+
+This section describes how CPaceOQUAKE+, the hybrid aPAKE from {{PQPAKE}},
+can be realized using out-of-band PAKE execution followed by TLS integration
+via External PSK Import {{?RFC9258}}. CPaceOQUAKE+ provides best-of-both-worlds
+security: it remains secure if either the classical assumptions underlying CPace
+or the post-quantum assumptions underlying OQUAKE+ hold.
+
+### Overview {#cpaceoquakeplus-overview}
+
+CPaceOQUAKE+ cannot be realized within a single TLS handshake because it requires
+more than two PAKE messages. This specification describes an out-of-band approach:
+
+1. CPace execution: Client and server execute CPace out-of-band to derive
+   a shared secret (ISK).
+2. OQUAKE+ execution: Client and server execute OQUAKE+ out-of-band using
+   the CPace ISK as context to derive a hybrid secret.
+3. TLS integration: Both parties import the hybrid secret as a PSK using
+   {{?RFC9258}} External PSK Import and establish a standard TLS PSK connection.
+
+The sequential composition provides hybrid security per the analysis in {{PQPAKE}}.
+The out-of-band approach eliminates complex TLS session binding and allows
+applications to control channel configuration.
+
+### Protocol Setup {#cpaceoquakeplus-setup}
+
+The TLS client and server roles map to the 'initiator' and 'responder' roles in
+both the CPace and OQUAKE+ specifications, respectively. Clients are configured
+with a password, client and server identities, and OQUAKE+ verifier material per
+{{Section 9.1.1 of PQPAKE}}. Servers are configured with corresponding password
+information and OQUAKE+ public key material.
+
+Both parties must support CPace and OQUAKE+ protocols for out-of-band execution.
+Applications configure out-of-band communication channels and TLS endpoints
+separately. Servers must implement state management to correlate out-of-band
+PAKE execution with subsequent TLS PSK connections.
+
+The sequential composition follows the CPaceOQUAKE+ construction from {{PQPAKE}},
+where CPace output serves as context input for OQUAKE+ to achieve hybrid security.
+
+### Protocol Execution {#cpaceoquakeplus-execution}
+
+The protocol execution follows three phases: CPace execution, OQUAKE+ execution
+with CPace context, and TLS PSK integration.
+
+~~~
+Client                                Server
+  |                                    |
+  |-- CPace.Init --------------------->|
+  |<-- CPace.Respond ------------------|
+  | (both derive cpace_isk)            |
+  |                                    |
+  |-- OQUAKE+.Init ------------------->|
+  |<-- OQUAKE+.Respond ----------------|
+  | (both derive hybrid_secret)        |
+  |                                    |
+  | (both: external_psk = Import(hybrid_secret, "TLS 1.3 CPaceOQUAKE+ PSK", context))
+  |                                    |
+  |-- TLS ClientHello ---------------->|
+  |    (with PSK extension)            |
+  |<-- TLS ServerHello ----------------|
+  |    (PSK selected)                  |
+  |-- [TLS handshake completion] ----->|
+  |<-- [TLS handshake completion] -----|
+~~~
+
+The detailed algorithm steps are:
+
+First, CPace executes. This consists of the following:
+
+~~~
+- client_cpace_msg = CPace.Init(password, identities)
+- server_cpace_msg = CPace.Respond(client_cpace_msg, password, identities)
+- cpace_isk = CPace.Finish(server_cpace_msg)  // Both parties derive ISK
+~~~
+
+Second, OQUAKE+ executes with the CPace context as input.
+This consists of the following:
+
+~~~
+- client_oquake_msg = OQUAKE+.Init(verifier, context=cpace_isk, identities)
+- server_oquake_msg = OQUAKE+.Respond(client_oquake_msg, verifier, pk, context=cpace_isk)
+- hybrid_secret = OQUAKE+.Finish(server_oquake_msg)  // Both parties derive final secret
+~~~
+
+The CPace ISK serves as context input for OQUAKE+ per the sequential combiner
+construction. Both protocols execute completely outside TLS on application-configured
+channels, with no intermediate TLS connections required.
+
+When finished with the PAKE(s), both parties derive a TLS PSK
+from the hybrid secret using {{?RFC9258}} External PSK Import.
+This consists of the following:
+
+~~~
+- external_psk = Import(hybrid_secret, "TLS 1.3 CPaceOQUAKE+ PSK", context) // From RFC9258
+- psk_identity = application_defined_identifier
+- Standard TLS 1.3 PSK handshake using (external_psk, psk_identity)
+~~~
+
+The External PSK Import uses the following parameters:
+
+- shared_secret: `hybrid_secret` from OQUAKE+.Finish output
+- label: `"TLS 1.3 CPaceOQUAKE+ PSK"`
+- context: Application-provided context or empty string
+- hash: Hash function matching the TLS cipher suite
+
+The TLS integration uses standard TLS 1.3 PSK mechanisms per {{Section 4.2.11 of !TLS13=RFC8446}}.
+The PSK identity can be application-defined, with session correlation handled at the
+application layer.
+
+### Implementation Considerations {#cpaceoquakeplus-implementation}
+
+Channel Security: Out-of-band channels must provide adequate confidentiality
+and integrity for PAKE message exchange. Applications are responsible for
+establishing secure communication channels for CPace and OQUAKE+ execution.
+
+State Management: Applications must correlate out-of-band PAKE execution with
+subsequent TLS connections. This includes managing PSK identities and ensuring
+proper cleanup of server state.
+
+Resource Management: Servers should limit concurrent out-of-band PAKE executions
+to prevent resource exhaustion attacks. Consider the cumulative computational cost
+of CPace and OQUAKE+ when setting limits.
+
+Dictionary Attack Mitigation: Building on the general guidance in {{security}},
+servers implementing out-of-band CPaceOQUAKE+ SHOULD:
+- Rate-limit CPace initiation attempts per client identity
+- Implement exponential backoff for failed out-of-band authentication attempts
+- Monitor for repeated failures across the entire out-of-band sequence
+- Consider the cumulative cost of CPace + OQUAKE+ execution when setting rate limits
+
+Failure Handling: CPace and OQUAKE+ failures should be treated as authentication
+attempts per the dictionary attack guidance. TLS PSK failures typically indicate
+implementation errors rather than authentication failures. Failed out-of-band
+sequences should trigger appropriate cleanup to prevent server state leaks.
 
 # Privacy Considerations {#privacy}
 
@@ -504,7 +874,7 @@ the authentication attempt MAY be treated as successful.
 
 Many of the security properties of this protocol will derive from
 the PAKE protocol being used. Security considerations for PAKE
-protocols are noted in {{compatible-pake-protocols}}.
+protocols are noted in {{internal-pake-protocols}}.
 
 If a server doesn't recognize the identity supplied by the
 client in the ClientHello `pake` extension, the server MAY abort the handshake with an
@@ -530,7 +900,12 @@ that learns the password could only impersonate a client to a server, but could 
 This is an important distinction in situations where
 the client sends sensitive data to the server.
 
-## SPAKE2+ Security Considerations {#spake2plus-sec}
+## Internal PAKE Security Considerations
+
+The following security considerations apply to Internal PAKEs that execute within
+the TLS handshake using the `pake` extension.
+
+### SPAKE2+ Security Considerations {#spake2plus-sec}
 
 {{spake2plus}} describes how to integrate SPAKE2+ into TLS using the `pake`
 extension in this document. This integration deviates from the SPAKE2+
@@ -539,13 +914,58 @@ checks required in {{SPAKE2PLUS}} are replaced with the TLS Finished messages.
 This is because the TLS Finished messages compute a MAC over the TLS transcript,
 which includes both the `shareP` and `shareV` values exchanged for SPAKE2+.
 
-[[OPEN ISSUE: this requires formal analysis to confirm.]]
+OPEN ISSUE: this requires formal analysis to confirm.
 
-## CPace Security Considerations {#cpace-sec}
+### CPace Security Considerations {#cpace-sec}
 
 {{cpace}} describes how to integrate CPace into TLS using the `pake`
 extension in this document. Key confirmation is provided via TLS 1.3 Finished messages,
 satisfying the requirements in {{Section 9.4 of !CPACE=I-D.irtf-cfrg-cpace}}.
+
+### OQUAKE Security Considerations {#oquake-sec}
+
+{{oquake}} describes how to integrate OQUAKE into TLS using the `pake`
+extension in this document. The OQUAKE response message includes an explicit
+key confirmation value `h` from server to client. The client MUST verify this
+value. Client-to-server key confirmation is provided via TLS 1.3 Finished
+messages.
+
+### OQUAKE+ Security Considerations {#oquakeplus-sec}
+
+{{oquakeplus}} describes how to integrate OQUAKE+ into TLS using the `pake`
+extension in this document. This integration deviates from the full OQUAKE+
+protocol in {{PQPAKE}} in one important way: the client does not send the
+final `server_confirm` message (msg3). Instead, client-to-server key
+confirmation is provided via TLS 1.3 Finished messages. This is analogous
+to how SPAKE2+ integration ({{spake2plus}}) omits `confirmP` in favor of
+TLS Finished.
+
+The TLS Finished messages compute a MAC over the TLS transcript, which includes
+both the OQUAKE+.Init and OQUAKE+.Respond messages. A client that cannot
+derive the correct `client_key` (because it does not know the password seed)
+cannot compute a valid Finished message, providing the server with equivalent
+assurance to the explicit `server_confirm` verification.
+
+OPEN ISSUE: this requires formal analysis to confirm.
+
+## External PAKE Security Considerations
+
+The following security considerations apply to External PAKEs that execute out-of-band
+prior to TLS connection establishment.
+
+### CPaceOQUAKE+ Security Considerations {#cpaceoquakeplus-sec}
+
+{{cpaceoquakeplus}} describes how to integrate CPaceOQUAKE+ using out-of-band
+execution followed by External PSK Import. The security of this composition relies on the sequential
+PAKE combiner analysis from {{PQPAKE}}: by providing the CPace-derived context
+to OQUAKE+, the effective password used in OQUAKE+ depends on both the original
+password and the CPace session key. This means an attacker must break both CPace
+and OQUAKE+ to mount an offline dictionary attack.
+
+The binding between connections is achieved through the TLS Exporter, which
+derives the context from the TLS Master Secret. An attacker that did not
+participate in the first CPace handshake cannot predict or influence the
+exported context value.
 
 # IANA Considerations
 
@@ -556,19 +976,22 @@ ExtensionType Registry with the following contents:
 |:------|:---------------|:-------:|:---------:|
 | 0xTODO   | pake           | CH, SH  | (this document)  |
 
-[[ RFC EDITOR: Please replace "TODO" in the above table with the
+RFC EDITOR: Please replace "TODO" in the above table with the
 value assigned by IANA, and replace "(this document)" with the
-RFC number assigned to this document. ]]
+RFC number assigned to this document.
 
 ## PAKE Scheme registry
 
 This document requests that IANA create a new registry called
-"PAKE Schemes" with the following contents:
+"PAKE Schemes" for internal PAKEs (those negotiated with the
+PAKE extension) with the following contents:
 
 | Value   | PAKEScheme | Reference | Notes |
 |:--------|:-----------|:---------:|:------|
 | 0xTODO  | SPAKE2PLUS_V1 | (this document) | N/A |
 | 0xTODO  | CPACE_X25519_SHA512 | (this document) | N/A |
+| 0xTODO  | OQUAKE_V1 | (this document) | N/A |
+| 0xTODO  | OQUAKE_PLUS_V1 | (this document) | N/A |
 
 The SPAKE2PLUS_V1 PAKEScheme variant has the following parameters associated with it:
 
@@ -591,6 +1014,24 @@ N =
 The CPACE_X25519_SHA512 PAKEScheme variant has the parameters for 'CPACE-X25519-SHA512'
 as specified in {{Section 4 of !CPACE=I-D.irtf-cfrg-cpace}}.
 
+The OQUAKE_V1 PAKEScheme variant has the following parameters associated with it:
+
+* BUA-sKEM: ML-BUA-sKEM1024
+* KDF: HKDF-SHA-256
+* DST: as specified in {{PQPAKE}}
+
+These parameters correspond to the RECOMMENDED configuration in {{PQPAKE}}.
+
+The OQUAKE_PLUS_V1 PAKEScheme variant has the following parameters associated with it:
+
+* BUA-sKEM: ML-BUA-sKEM1024
+* KEM: X-Wing {{XWING}}
+* KDF: HKDF-SHA-256
+* KSF: Argon2id {{ARGON2}} (parameters as specified in {{PQPAKE}})
+* DST: as specified in {{PQPAKE}}
+
+These parameters correspond to the RECOMMENDED configuration in {{PQPAKE}}.
+
 # Acknowledgments
 {:numbered="false"}
 
@@ -600,6 +1041,11 @@ document.
 
 # Change Log
 {:numbered="false"}
+
+Since draft-ietf-tls-pake-01
+
+* Add internal and external PAKE distinction
+* Add OQUAKE and OQUAKE+ from draft-vos-cfrg-pqpake.
 
 Since draft-ietf-tls-pake-00
 
@@ -616,7 +1062,6 @@ Since draft-ietf-tls-pake-00
   supported_groups extensions
 * Specify that SPAKE2+ Context string MUST be prefixed with "tls"
   to prevent cross-protocol attacks
-
 
 Since draft-bmw-tls-pake13-02
 


### PR DESCRIPTION
Add internal and external distinction, and add OQUAKE and OQUAKE+ as internal variants.